### PR TITLE
Replace unmaintained lazy_static dependency with once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 home = "0.5"
-lazy_static = "1.4"
+once_cell = "1"
 regex = "1.4"
 semver = "0.11"
 walkdir = "2.3"


### PR DESCRIPTION
`once_cell` is the successor to the very old `lazy_static` crate. Unlike `lazy_static` its API is not based on macros, so it plays nicer with tooling like rustfmt and rust-analyzer.

The approach from `once_cell` is very close to how this functionality is getting introduced into the standard library (but the standard library's OnceCell is not stable yet).