### PR TITLE
Add find_nightly_installed_component

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,19 +5,18 @@ name: CI
 jobs:
   check:
     name: test
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        run: |
+          rustup toolchain install stable --profile minimal
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: |
+          cargo test

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/gsquire/toolchain_find/badge.svg?branch=master)](https://coveralls.io/github/gsquire/toolchain_find?branch=master)
 
-This is a small crate that exposes a single function to find a component installed across all
-toolchains managed by rustup.
+This is a small crate that exposes two functions:
+
+- `find_installed_component` to find a component installed across all toolchains managed by rustup.
+- `find_nightly_installed_component` to find a component installed across nightly toolchains managed by rustup.
 
 ## Documentation
 [Link](https://docs.rs/toolchain_find)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,12 @@ use regex::Regex;
 use semver::Version;
 use walkdir::WalkDir;
 
+#[derive(Clone, Copy)]
+enum Toolchains {
+    All,
+    Nightly,
+}
+
 // A `Component` keeps track of the rustc version associated with the component in question.
 #[derive(Debug)]
 struct Component {
@@ -86,6 +92,18 @@ fn rustc_version(bin_path: &Path) -> Option<DateVersion> {
 /// on the system to see if it is installed. It will return the path of the component that has
 /// the latest version.
 pub fn find_installed_component(name: &str) -> Option<PathBuf> {
+    find_installed(name, Toolchains::All)
+}
+
+/// Given a Rust component name, search through all of the available nightly toolchains
+/// on the system to see if it is installed. It will return the path of the component that has
+/// the latest version.
+pub fn find_nightly_installed_component(name: &str) -> Option<PathBuf> {
+    find_installed(name, Toolchains::Nightly)
+}
+
+/// Find an installed component name, optionally filtering to nightly toolchains.
+fn find_installed(name: &str, toolchains: Toolchains) -> Option<PathBuf> {
     let mut components = Vec::new();
     let mut root = home::rustup_home().ok()?;
     root.push("toolchains");
@@ -102,6 +120,16 @@ pub fn find_installed_component(name: &str) -> Option<PathBuf> {
     for entry in WalkDir::new(root)
         .max_depth(3)
         .into_iter()
+        .filter_entry(|e| {
+            e.depth() != 1
+                || match toolchains {
+                    Toolchains::All => true,
+                    Toolchains::Nightly => e
+                        .path()
+                        .file_name()
+                        .is_some_and(|f| f.to_string_lossy().starts_with("nightly")),
+                }
+        })
         .filter_map(|e| e.ok())
     {
         let parent = entry.path().parent()?;

--- a/tests/nightly.rs
+++ b/tests/nightly.rs
@@ -1,0 +1,85 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+// Keep this file to one #[test]. Environment variables are process-wide, and
+// libtest runs tests within the same test binary in parallel by default.
+
+#[test]
+fn find_nightly_installed_component_ignores_newer_stable() {
+    let root = temp_rustup_home("nightly-ignores-newer-stable");
+    let stable = add_toolchain(
+        &root,
+        "stable-x86_64-unknown-linux-gnu",
+        "rustc 1.95.0 (000000000 2026-03-01)",
+    );
+
+    unsafe {
+        std::env::set_var("RUSTUP_HOME", &root);
+    }
+    assert_eq!(
+        toolchain_find::find_nightly_installed_component("rustfmt"),
+        None
+    );
+
+    let nightly = add_toolchain(
+        &root,
+        "nightly-2026-01-01-x86_64-unknown-linux-gnu",
+        "rustc 1.94.1-nightly (000000000 2026-01-01)",
+    );
+    assert_eq!(
+        toolchain_find::find_installed_component("rustfmt"),
+        Some(stable)
+    );
+    assert_eq!(
+        toolchain_find::find_nightly_installed_component("rustfmt"),
+        Some(nightly)
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+fn temp_rustup_home(test_name: &str) -> PathBuf {
+    let root =
+        std::env::temp_dir().join(format!("toolchain_find-{test_name}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("toolchains")).unwrap();
+    root
+}
+
+fn add_toolchain(root: &Path, toolchain: &str, rustc_version: &str) -> PathBuf {
+    let bin = root.join("toolchains").join(toolchain).join("bin");
+    fs::create_dir_all(&bin).unwrap();
+    let rustfmt = bin.join(exe_name("rustfmt"));
+    fs::write(&rustfmt, "").unwrap();
+    let rustc = bin.join(exe_name("rustc"));
+    write_fake_rustc(&rustc, rustc_version);
+    rustfmt
+}
+
+fn exe_name(name: &str) -> String {
+    if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    }
+}
+
+fn write_fake_rustc(path: &Path, version: &str) {
+    let source = path.with_extension("rs");
+    fs::write(
+        &source,
+        format!("fn main() {{ println!(\"{}\"); }}", version),
+    )
+    .unwrap();
+
+    let status = Command::new("rustc")
+        .env_remove("RUSTUP_HOME")
+        .arg(&source)
+        .arg("-o")
+        .arg(path)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let _ = fs::remove_file(source);
+}


### PR DESCRIPTION
- Adds `find_nightly_installed_component`
- Closes: #19
- ci: Add testing under mac and windows
- ci: Stop using actions-rs/ layers (base GHA now includes rustup/cargo)

I tried to make this as small a change as possible to reduce the risk of accidentally changing behavior for the existing function. The `nightly` test is a little complex, but I (a) didn't want to introduce a new untested entrypoint (b) wanted to avoid decomposing the existing functionality into testable parts.

btw, no rush on this if you'd like to consider an alternate approach. 

LLM Disclosure: I wrote the code largely by hand, but used Codex with GPT-5.5 High to construct the integration test.