### PR TITLE
feat: release new nightly API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toolchain_find"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Garrett Squire <github@garrettsquire.com>"]
 edition = "2021"
 license = "MIT"
@@ -11,7 +11,6 @@ readme = "README.md"
 
 [dependencies]
 home = "0.5"
-once_cell = "1"
-regex = "1.8"
+regex = "1.12"
 semver = "1"
-walkdir = "2.3"
+walkdir = "2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "toolchain_find"
 version = "0.5.0"
 authors = ["Garrett Squire <github@garrettsquire.com>"]
-edition = "2021"
+edition = "2024"
 license = "MIT"
 repository = "https://github.com/gsquire/toolchain_find"
 documentation = "https://docs.rs/toolchain_find"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,13 @@ use std::cmp::Ordering;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str;
+use std::sync::OnceLock;
 
-use once_cell::sync::OnceCell;
 use regex::Regex;
 use semver::Version;
 use walkdir::WalkDir;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 enum Toolchains {
     All,
     Nightly,
@@ -59,7 +59,7 @@ impl Component {
 
 // Given the version string from rustc, attempt to parse the date.
 fn parse_rustc_date(rustc_v: &[u8]) -> Option<DateVersion> {
-    static PATTERN: OnceCell<Regex> = OnceCell::new();
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
 
     // This may not be the most ideal way to get the version.
     // It assumes that the output looks like:


### PR DESCRIPTION
This patch adds a new nightly lookup function. The once_cell crate is removed as a dependency favoring the standard library.