### PR TITLE
Follow symbolic links while finding installed component

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ fn find_installed(name: &str, toolchains: Toolchains) -> Option<PathBuf> {
 
     for entry in WalkDir::new(root)
         .max_depth(3)
+        .follow_links(true)
         .into_iter()
         .filter_entry(|e| {
             e.depth() != 1


### PR DESCRIPTION
The `WalkDir` is default to not follow symbolic links.
This is a problem in Gentoo Linux where their own toolchain `gentoo` is a symbolic link.