### PR TITLE
test: exercise symbolic link following

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
+test_helpers/target
 **/*.rs.bk
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ home = "0.5"
 regex = "1.12"
 semver = "1"
 walkdir = "2.5"
+
+[dev-dependencies]
+googletest = "0.14"
+test_helpers = { path = "test_helpers" }

--- a/test_helpers/Cargo.toml
+++ b/test_helpers/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "test_helpers"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_helpers/src/lib.rs
+++ b/test_helpers/src/lib.rs
@@ -1,0 +1,52 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub fn temp_rustup_home(test_name: &str) -> PathBuf {
+    let root =
+        std::env::temp_dir().join(format!("toolchain_find-{test_name}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("toolchains")).unwrap();
+    root
+}
+
+pub fn add_toolchain(root: &Path, toolchain: &str, rustc_version: &str) -> PathBuf {
+    let bin = root.join("toolchains").join(toolchain).join("bin");
+    fs::create_dir_all(&bin).unwrap();
+    let lib = root.join("toolchains").join(toolchain).join("lib");
+    fs::create_dir_all(&lib).unwrap();
+
+    let rustfmt = bin.join(exe_name("rustfmt"));
+    fs::write(&rustfmt, "").unwrap();
+    let rustc = bin.join(exe_name("rustc"));
+    write_fake_rustc(&rustc, rustc_version);
+    rustfmt
+}
+
+fn exe_name(name: &str) -> String {
+    if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    }
+}
+
+fn write_fake_rustc(path: &Path, version: &str) {
+    let source = path.with_extension("rs");
+    fs::write(
+        &source,
+        format!("fn main() {{ println!(\"{}\"); }}", version),
+    )
+    .unwrap();
+
+    let status = Command::new("rustc")
+        .env_remove("RUSTUP_HOME")
+        .arg(&source)
+        .arg("-o")
+        .arg(path)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let _ = fs::remove_file(source);
+}

--- a/tests/nightly.rs
+++ b/tests/nightly.rs
@@ -1,6 +1,6 @@
 use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+
+use test_helpers::{add_toolchain, temp_rustup_home};
 
 // Keep this file to one #[test]. Environment variables are process-wide, and
 // libtest runs tests within the same test binary in parallel by default.
@@ -36,50 +36,4 @@ fn find_nightly_installed_component_ignores_newer_stable() {
         Some(nightly)
     );
     let _ = fs::remove_dir_all(root);
-}
-
-fn temp_rustup_home(test_name: &str) -> PathBuf {
-    let root =
-        std::env::temp_dir().join(format!("toolchain_find-{test_name}-{}", std::process::id()));
-    let _ = fs::remove_dir_all(&root);
-    fs::create_dir_all(root.join("toolchains")).unwrap();
-    root
-}
-
-fn add_toolchain(root: &Path, toolchain: &str, rustc_version: &str) -> PathBuf {
-    let bin = root.join("toolchains").join(toolchain).join("bin");
-    fs::create_dir_all(&bin).unwrap();
-    let rustfmt = bin.join(exe_name("rustfmt"));
-    fs::write(&rustfmt, "").unwrap();
-    let rustc = bin.join(exe_name("rustc"));
-    write_fake_rustc(&rustc, rustc_version);
-    rustfmt
-}
-
-fn exe_name(name: &str) -> String {
-    if cfg!(windows) {
-        format!("{name}.exe")
-    } else {
-        name.to_string()
-    }
-}
-
-fn write_fake_rustc(path: &Path, version: &str) {
-    let source = path.with_extension("rs");
-    fs::write(
-        &source,
-        format!("fn main() {{ println!(\"{}\"); }}", version),
-    )
-    .unwrap();
-
-    let status = Command::new("rustc")
-        .env_remove("RUSTUP_HOME")
-        .arg(&source)
-        .arg("-o")
-        .arg(path)
-        .status()
-        .unwrap();
-    assert!(status.success());
-
-    let _ = fs::remove_file(source);
 }

--- a/tests/symlink.rs
+++ b/tests/symlink.rs
@@ -1,0 +1,45 @@
+use std::path::Path;
+use std::process::Command;
+use std::{env, fs};
+
+use googletest::prelude::*;
+use test_helpers::{add_toolchain, temp_rustup_home};
+use toolchain_find::find_installed_component;
+
+#[test]
+fn find_installed_component_follows_symbolic_links() {
+    let sym_home = temp_rustup_home("symlink");
+    let _ = add_toolchain(
+        &sym_home,
+        "stable-x86_64-unknown-linux-gnu",
+        "rustc 1.95.0 (000000000 2026-03-01)",
+    );
+
+    unsafe {
+        env::set_var("RUSTUP_HOME", &sym_home);
+    }
+
+    let target = Path::new(&sym_home)
+        .join("toolchains")
+        .join("stable-x86_64-unknown-linux-gnu");
+    let status = Command::new("rustup")
+        .arg("toolchain")
+        .arg("link")
+        .arg("zzz")
+        .arg(target)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    // Sort of a hack but we're relying on the fact that our components are sorted before being
+    // returned.
+    assert_that!(
+        find_installed_component("rustfmt")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        contains_substring("zzz")
+    );
+
+    let _ = fs::remove_dir_all(sym_home);
+}


### PR DESCRIPTION
This patch adds an integration test that ensures symbolic links are followed.

Refs: #22